### PR TITLE
Added windowsVerbatimArguments to spawn options

### DIFF
--- a/src/netsuite-sdf.ts
+++ b/src/netsuite-sdf.ts
@@ -687,7 +687,8 @@ export class NetSuiteSDF {
 
       this.sdfcli = spawn('sdfcli', commandArray, {
         cwd: this.rootPath,
-        stdin: stdinSubject
+        stdin: stdinSubject,
+        windowsVerbatimArguments: true
       });
 
       this.showStatus();


### PR DESCRIPTION
windowsVerbatimArguments skips the wrapping of each commandArray member in a set of double quotes.  This is necessary because there are already double quotes inserted by the sdfcli batch file.

There may be other side effects to this option that I have not explored.

