### PR TITLE
remove minimum engine req

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "repository": "https://github.com/mark-keaton/NetSuiteSDF",
   "engines": {
-    "vscode": "^1.1.22"
+    "vscode": "*"
   },
   "categories": [
     "Other"

--- a/package.json
+++ b/package.json
@@ -309,6 +309,7 @@
     "rxjs": "^5.5.10",
     "spawn-rx": "~2.0.12",
     "tmp": "0.0.33",
+    "vscode": "^1.1.30",
     "xml2js": "^0.4.19"
   },
   "devDependencies": {


### PR DESCRIPTION
Remove the minimum engine requirement so that the install script can pull the most recent master copy of the vscode.d.ts file.