### PR TITLE
Correct Win32 paths in deploy.xml

### DIFF
--- a/src/netsuite-sdf.ts
+++ b/src/netsuite-sdf.ts
@@ -556,7 +556,7 @@ export class NetSuiteSDF {
       return;
     }
     const xmlPath = isScript ? 'deploy.files[0].path' : 'deploy.objects[0].path';
-    const relativePath = _.replace(currentFile, this.rootPath, '~');
+    const relativePath = _.replace(currentFile, this.rootPath, '~').replace(/\\/gi, "/");
 
     const deployXmlExists = await this.fileExists(deployPath);
     if (!deployXmlExists) {


### PR DESCRIPTION
When using 'Add current/selected file to deploy.xml' on windows, the path is formatted with win32 separators, "\"
    ex: 
    <deploy>
      <objects>
        <path>~\Objects\MyObj\customscript_myscript.xml</path>
      </objects>

However sdfcli needs posix separators, "/" and using sdfcli deploy will report an error:
      An error occurred during deploy file validation.
      Details: The file value ~\Objects\Nautilus\Scripts\GL_Plugins\customscript_nls_gl_itemreceipt.xml in the deploy file must start with 
      the ~/ character and must not contain the following characters: ?, *, <, >, |, ', \\, space.
      File: ~/deploy.xml

the correct format should be: 
    <deploy>
      <objects>
        <path>~/Objects/MyObj/customscript_myscript.xml</path>
      </objects>